### PR TITLE
Add a script that makes a combined PDF of the whole repo!

### DIFF
--- a/.build/make-book.fish
+++ b/.build/make-book.fish
@@ -1,0 +1,18 @@
+#!/usr/bin/fish
+
+# Remove any existing rendered files 
+rm -f combined.rendered.md
+rm -f OpenYourMouth-book.pdf
+
+# todo: output front matter and some pandoc macros to generate a table of contents
+
+# Depth-first search of each md file, catted together and adding a pagebrak macro
+for mdfile in ( fdfind .md | grep -v README.md )
+    cat $mdfile >> combined.rendered.md
+    echo "" >> combined.rendered.md
+    echo "\\pagebreak" >> combined.rendered.md
+    echo "" >> combined.rendered.md
+end
+
+# make into a pdf
+pandoc --from markdown+raw_tex -o OpenYourMouth-book.pdf combined.rendered.md 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Vim swap files
 *.swp
+
+# Outputs from builds.
+*.rendered.md
+*.pdf

--- a/Sandwiches/MediterraneanChickenSandwich.md
+++ b/Sandwiches/MediterraneanChickenSandwich.md
@@ -1,12 +1,10 @@
 # Mediterranean Chicken Sandwich
 ## Mediterranean chicken with swiss cheese on a croissant
 
-
-
 ### Ingredients
 |Required Items                              | US         |Metric 	  |
 |:-------------------------------------------|:-----------|:----------|
-| Mediterranean Chicken Skewwers from Costco | 2 Skewers  | 2 Skewers |
+| Mediterranean Chicken Skewers from Costco | 2 Skewers  | 2 Skewers |
 | Swiss Cheese                               | 1 Slice    | 1 Slice   |
 | Large Croissant                            | 1          | 1         |
 
@@ -19,8 +17,4 @@
 5. Place the other half of the croissant on the cheese and other items
 6. Micorwave for 45 seconds or untill cheese is slightly melted and chicken is warm
 
-### Ingredient Images
-This is to make things easy to identify on the costco trip. Since the cheese and croissants are obvious I am only showing the chicken.
-
-![Mediterranean Chicken](http://www.exprescofoods.com/wp-content/uploads/2013/05/FC-Chicken-Skewers_Costco-CAN-Deli_32451437.jpg "Mediterranean Chicken")
 

--- a/Vegetarian/EnchiladaPie.md
+++ b/Vegetarian/EnchiladaPie.md
@@ -36,7 +36,7 @@ You can use any oven proof container, but I would higly recommend using a spring
 4. Add crushed tomatoes and let simmer for 5 minutes. 
 
 #### Filling
-1. Heat olive i\oil in a large pot on medium heat.
+1. Heat olive oil in a large pot on medium heat.
 2. Fry onion for 5 minutes.
 3. Add jalapenos, garlic, cumin, salt and pepper and fry for a minute. 
 4. Add beans, sweet corn and shallots.  


### PR DESCRIPTION
I love browsing these recipes directly on GitHub in a web browser, but sometimes you just want a nice PDF.

I added a fish-shell script which `cat`s all the markdown files together, inserts the `\pagebreak` TeX macro, then uses `pandoc` to convert this omni-markdown file into a PDF file.

While setting this up, I noticed some issues in two recipes:

1. The Mediterranean chicken sandwich recipe had an image embed which is 404ing, so I removed it.
2. The Enchiada pie recipe had a typo that was choking the `pandoc`-internal TeX parser.

Here's the current result:
[OpenYourMouth-book.pdf](https://github.com/elementc/OpenYourMouth/files/9893053/OpenYourMouth-book.pdf)

I might hook up some automation that runs this at a later date.

I'm participating in Hacktoberfest. If you think this is a valuable contribution, consider applying the `hacktoberfest-accepted` label to this PR so I can get credit.

Thanks!